### PR TITLE
Add own dump extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
     "symfony/config": "^5.4.31|^6.4.0|^7.0.0",
     "symfony/dependency-injection": "^5.4.33|^6.4.1|^7.0.1",
     "symfony/http-kernel": "^5.4.33|^6.4.1|^7.0.1",
+    "symfony/var-dumper": "^5.4.29|^6.4.0|^7.0.0",
     "twig/twig": "^3.5.0"
   },
   "require-dev": {
@@ -38,7 +39,6 @@
     "phpunit/phpunit": "^10.5.2",
     "psalm/plugin-symfony": "^5.1.0",
     "roave/security-advisories": "dev-master",
-    "symfony/var-dumper": "^5.4.29|^6.4.0|^7.0.0",
     "vimeo/psalm": "^5.17.0"
   },
   "config": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1e69c8802e99f729173b5cf54165e820",
+    "content-hash": "c4ebd1bf90775a94f2c432233d381261",
     "packages": [
         {
             "name": "brick/math",
@@ -3478,16 +3478,16 @@
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v7.0.6",
+            "version": "v7.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "66d13dc207d5dab6b4f4c2b5460efe1bea29dbfb"
+                "reference": "c6a22929407dec8765d6e2b6ff85b800b245879c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/66d13dc207d5dab6b4f4c2b5460efe1bea29dbfb",
-                "reference": "66d13dc207d5dab6b4f4c2b5460efe1bea29dbfb",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/c6a22929407dec8765d6e2b6ff85b800b245879c",
+                "reference": "c6a22929407dec8765d6e2b6ff85b800b245879c",
                 "shasum": ""
             },
             "require": {
@@ -3503,7 +3503,7 @@
                 "symfony/http-kernel": "^6.4|^7.0",
                 "symfony/process": "^6.4|^7.0",
                 "symfony/uid": "^6.4|^7.0",
-                "twig/twig": "^3.0.4"
+                "twig/twig": "^3.12"
             },
             "bin": [
                 "Resources/bin/var-dump-server"
@@ -3541,7 +3541,7 @@
                 "dump"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-dumper/tree/v7.0.6"
+                "source": "https://github.com/symfony/var-dumper/tree/v7.2.0"
             },
             "funding": [
                 {
@@ -3557,7 +3557,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-03-19T11:57:22+00:00"
+            "time": "2024-11-08T15:48:14+00:00"
         },
         {
             "name": "symfony/var-exporter",
@@ -8833,6 +8833,6 @@
     "platform": {
         "php": "~8.1.0 || ~8.2.0 || ~8.3.0"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "plugin-api-version": "2.6.0"
 }

--- a/src/Controller/InspectionController.php
+++ b/src/Controller/InspectionController.php
@@ -47,7 +47,6 @@ final class InspectionController
     public function indexAction(Request $request): Response
     {
         if ($request->getMethod() === 'POST') {
-
             $aggregateName = $request->get('aggregate');
             $aggregateId = $request->get('aggregateId');
 

--- a/src/Controller/SubscriptionController.php
+++ b/src/Controller/SubscriptionController.php
@@ -4,16 +4,20 @@ declare(strict_types=1);
 
 namespace Patchlevel\EventSourcingAdminBundle\Controller;
 
-use Patchlevel\EventSourcing\Subscription\Status;
-use Patchlevel\EventSourcing\Subscription\RunMode;
+use Patchlevel\EventSourcing\Store\Store;
 use Patchlevel\EventSourcing\Subscription\Engine\SubscriptionEngine;
 use Patchlevel\EventSourcing\Subscription\Engine\SubscriptionEngineCriteria;
-use Patchlevel\EventSourcing\Store\Store;
+use Patchlevel\EventSourcing\Subscription\RunMode;
+use Patchlevel\EventSourcing\Subscription\Status;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\RouterInterface;
 use Twig\Environment;
+
+use function array_keys;
+use function array_map;
+use function str_contains;
 
 final class SubscriptionController
 {
@@ -42,7 +46,6 @@ final class SubscriptionController
         $mode = $request->get('mode');
         $status = $request->get('status');
 
-
         foreach ($subscriptions as $subscription) {
             if ($search && !str_contains($subscription->id(), $search)) {
                 continue;
@@ -67,8 +70,8 @@ final class SubscriptionController
             $this->twig->render('@PatchlevelEventSourcingAdmin/subscription/show.html.twig', [
                 'subscriptions' => $filteredSubscriptions,
                 'messageCount' => $messageCount,
-                'statuses' => array_map(fn (Status $status) => $status->value, Status::cases()),
-                'modes' => array_map(fn (RunMode $mode) => $mode->value, RunMode::cases()),
+                'statuses' => array_map(static fn (Status $status) => $status->value, Status::cases()),
+                'modes' => array_map(static fn (RunMode $mode) => $mode->value, RunMode::cases()),
                 'groups' => array_keys($groups),
             ]),
         );

--- a/src/Decorator/RequestIdDecorator.php
+++ b/src/Decorator/RequestIdDecorator.php
@@ -1,18 +1,19 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Patchlevel\EventSourcingAdminBundle\Decorator;
 
-use Patchlevel\EventSourcing\Repository\MessageDecorator\MessageDecorator;
 use Patchlevel\EventSourcing\Message\Message;
+use Patchlevel\EventSourcing\Repository\MessageDecorator\MessageDecorator;
 use Patchlevel\EventSourcingAdminBundle\Listener\RequestIdListener;
 use Symfony\Component\HttpFoundation\RequestStack;
 
 class RequestIdDecorator implements MessageDecorator
 {
     public function __construct(
-        private readonly RequestStack $requestStack
-    )
-    {
+        private readonly RequestStack $requestStack,
+    ) {
     }
 
     public function __invoke(Message $message): Message

--- a/src/DependencyInjection/PatchlevelEventSourcingAdminExtension.php
+++ b/src/DependencyInjection/PatchlevelEventSourcingAdminExtension.php
@@ -15,10 +15,9 @@ use Patchlevel\EventSourcing\Store\Store;
 use Patchlevel\EventSourcing\Subscription\Engine\SubscriptionEngine;
 use Patchlevel\EventSourcingAdminBundle\Controller\DefaultController;
 use Patchlevel\EventSourcingAdminBundle\Controller\EventController;
-use Patchlevel\EventSourcingAdminBundle\Controller\GraphController;
 use Patchlevel\EventSourcingAdminBundle\Controller\InspectionController;
-use Patchlevel\EventSourcingAdminBundle\Controller\SubscriptionController;
 use Patchlevel\EventSourcingAdminBundle\Controller\StoreController;
+use Patchlevel\EventSourcingAdminBundle\Controller\SubscriptionController;
 use Patchlevel\EventSourcingAdminBundle\Decorator\RequestIdDecorator;
 use Patchlevel\EventSourcingAdminBundle\Listener\RequestIdListener;
 use Patchlevel\EventSourcingAdminBundle\Listener\TokenMapperListener;
@@ -37,7 +36,6 @@ use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\Routing\RouterInterface;
-use Symfony\Component\VarDumper\Cloner\ClonerInterface;
 
 /**
  * @psalm-type Config = array{
@@ -125,9 +123,6 @@ final class PatchlevelEventSourcingAdminExtension extends Extension
             ->addTag('twig.extension');
 
         $container->register(DumpExtension::class)
-            ->setArguments([
-                new Reference(ClonerInterface::class),
-            ])
             ->addTag('twig.extension');
 
         $container->register(RequestIdDecorator::class)

--- a/src/DependencyInjection/PatchlevelEventSourcingAdminExtension.php
+++ b/src/DependencyInjection/PatchlevelEventSourcingAdminExtension.php
@@ -24,6 +24,7 @@ use Patchlevel\EventSourcingAdminBundle\Listener\RequestIdListener;
 use Patchlevel\EventSourcingAdminBundle\Listener\TokenMapperListener;
 use Patchlevel\EventSourcingAdminBundle\Projection\TraceProjector;
 use Patchlevel\EventSourcingAdminBundle\TokenMapper;
+use Patchlevel\EventSourcingAdminBundle\Twig\DumpExtension;
 use Patchlevel\EventSourcingAdminBundle\Twig\EventSourcingAdminExtension;
 use Patchlevel\EventSourcingAdminBundle\Twig\HeroiconsExtension;
 use Patchlevel\EventSourcingAdminBundle\Twig\InspectionExtension;
@@ -120,6 +121,9 @@ final class PatchlevelEventSourcingAdminExtension extends Extension
             ->setArguments([
                 new Reference('event_sourcing_admin.expression_language'),
             ])
+            ->addTag('twig.extension');
+
+        $container->register(DumpExtension::class)
             ->addTag('twig.extension');
 
         $container->register(RequestIdDecorator::class)

--- a/src/DependencyInjection/PatchlevelEventSourcingAdminExtension.php
+++ b/src/DependencyInjection/PatchlevelEventSourcingAdminExtension.php
@@ -37,6 +37,7 @@ use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\VarDumper\Cloner\ClonerInterface;
 
 /**
  * @psalm-type Config = array{
@@ -124,6 +125,9 @@ final class PatchlevelEventSourcingAdminExtension extends Extension
             ->addTag('twig.extension');
 
         $container->register(DumpExtension::class)
+            ->setArguments([
+                new Reference(ClonerInterface::class),
+            ])
             ->addTag('twig.extension');
 
         $container->register(RequestIdDecorator::class)

--- a/src/Listener/RequestIdListener.php
+++ b/src/Listener/RequestIdListener.php
@@ -23,7 +23,7 @@ class RequestIdListener
 
         $request = $event->getRequest();
 
-        $requestId = substr(hash('sha256', uniqid(mt_rand(), true)), 0, 6);
+        $requestId = substr(hash('sha256', uniqid((string)mt_rand(), true)), 0, 6);
 
         $request->attributes->set(self::REQUEST_ID_ATTRIBUTE, $requestId);
     }

--- a/src/Listener/RequestIdListener.php
+++ b/src/Listener/RequestIdListener.php
@@ -1,8 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Patchlevel\EventSourcingAdminBundle\Listener;
 
 use Symfony\Component\HttpKernel\Event\RequestEvent;
+
+use function hash;
+use function mt_rand;
+use function substr;
+use function uniqid;
 
 class RequestIdListener
 {

--- a/src/Listener/TokenMapperListener.php
+++ b/src/Listener/TokenMapperListener.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Patchlevel\EventSourcingAdminBundle\Listener;
 
 use Patchlevel\EventSourcingAdminBundle\TokenMapper;

--- a/src/Projection/Link.php
+++ b/src/Projection/Link.php
@@ -1,8 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Patchlevel\EventSourcingAdminBundle\Projection;
 
 use JsonSerializable;
+
+use function sha1;
 
 final class Link implements JsonSerializable
 {

--- a/src/Projection/Node.php
+++ b/src/Projection/Node.php
@@ -1,8 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Patchlevel\EventSourcingAdminBundle\Projection;
 
 use JsonSerializable;
+
+use function sha1;
 
 final class Node implements JsonSerializable
 {

--- a/src/TokenMapper.php
+++ b/src/TokenMapper.php
@@ -1,12 +1,19 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Patchlevel\EventSourcingAdminBundle;
+
+use function fclose;
+use function fgetcsv;
+use function file_exists;
+use function fopen;
+use function fputcsv;
+use function touch;
 
 class TokenMapper
 {
-    /**
-     * @var array<string, string>
-     */
+    /** @var array<string, string> */
     private array $map = [];
 
     public function __construct(private readonly string $path)
@@ -23,7 +30,7 @@ class TokenMapper
         $this->write($requestId, $debugToken);
     }
 
-    public function get(string $requestId): ?string
+    public function get(string $requestId): string|null
     {
         if ($this->map === []) {
             $this->map = $this->load();

--- a/src/Twig/DumpExtension.php
+++ b/src/Twig/DumpExtension.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcingAdminBundle\Twig;
+
+use Symfony\Component\VarDumper\Cloner\ClonerInterface;
+use Symfony\Component\VarDumper\Dumper\HtmlDumper;
+use Twig\Environment;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+final class DumpExtension extends AbstractExtension
+{
+    public function __construct(
+        private ClonerInterface $cloner,
+        private ?HtmlDumper $dumper = null,
+    ) {
+    }
+
+    /** @return list<TwigFunction> */
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction(
+                'eventsourcing_dump',
+                $this->dump(...),
+                [
+                    'is_safe' => ['html'],
+                    'needs_environment' => true,
+                ]
+            ),
+        ];
+    }
+
+    public function dump(Environment $env, mixed $var): string
+    {
+        $dump = fopen('php://memory', 'r+');
+        $this->dumper ??= new HtmlDumper();
+        $this->dumper->setCharset($env->getCharset());
+
+        $this->dumper->dump($this->cloner->cloneVar($var), $dump);
+
+        return stream_get_contents($dump, -1, 0);
+    }
+}

--- a/src/Twig/EventSourcingAdminExtension.php
+++ b/src/Twig/EventSourcingAdminExtension.php
@@ -75,7 +75,7 @@ final class EventSourcingAdminExtension extends AbstractExtension
         )->payload;
     }
 
-    public function profilerToken(Message $message): ?string
+    public function profilerToken(Message $message): string|null
     {
         return null;
 

--- a/src/Twig/InspectionExtension.php
+++ b/src/Twig/InspectionExtension.php
@@ -12,6 +12,7 @@ use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
 use function count;
+use function is_object;
 use function preg_replace;
 use function preg_replace_callback;
 
@@ -36,9 +37,7 @@ final class InspectionExtension extends AbstractExtension
         ];
     }
 
-    /**
-     * @param class-string|object $event
-     */
+    /** @param class-string|object $event */
     private function icon(object|string $event, string|null $default = null): string|null
     {
         $inspect = $this->inspect($event);
@@ -46,9 +45,7 @@ final class InspectionExtension extends AbstractExtension
         return $inspect->icon ?: $default;
     }
 
-    /**
-     * @param class-string|object $event
-     */
+    /** @param class-string|object $event */
     private function color(object|string $event, string|Color|null $default = null): string|null
     {
         $inspect = $this->inspect($event);
@@ -91,9 +88,7 @@ final class InspectionExtension extends AbstractExtension
         );
     }
 
-    /**
-     * @param class-string|object $event
-     */
+    /** @param class-string|object $event */
     private function descriptionRaw(object|string $event, string|null $default = null): string|null
     {
         $inspect = $this->inspect($event);
@@ -101,9 +96,7 @@ final class InspectionExtension extends AbstractExtension
         return $inspect->description ?: $default;
     }
 
-    /**
-     * @param class-string|object $event
-     */
+    /** @param class-string|object $event */
     private function inspect(object|string $event): Inspect
     {
         if (is_object($event)) {

--- a/templates/inspection/show.html.twig
+++ b/templates/inspection/show.html.twig
@@ -96,7 +96,7 @@
                     {% endif %}
 
                     {% if tab == 'dump' %}
-                        {{ dump(aggregate) }}
+                        {{ eventsourcing_dump(aggregate) }}
                     {% endif %}
 
                     {% if tab == 'serialized' %}
@@ -146,7 +146,7 @@
                         {% endif %}
 
                         {% if snapshot %}
-                            {{ dump(snapshot) }}
+                            {{ eventsourcing_dump(snapshot) }}
                         {% endif %}
                     {% endif %}
                 </div>


### PR DESCRIPTION
Fix #16 

I decided to create an own `dump` extension due to how and when symfony registers their own extension. They are doing it in the debug bundle, which we dont want to pull intro production. This solution is enough for our purposes in the dashboard.