### PR TITLE
Refactor EventSourcingAdminExtension to use ServiceSubscriberInterface for dependency management

### DIFF
--- a/src/DependencyInjection/PatchlevelEventSourcingAdminExtension.php
+++ b/src/DependencyInjection/PatchlevelEventSourcingAdminExtension.php
@@ -102,13 +102,11 @@ final class PatchlevelEventSourcingAdminExtension extends Extension
             ->addTag('controller.service_arguments');
 
         $container->register(EventSourcingAdminExtension::class)
-            ->setArguments([
-                new Reference(AggregateRootRegistry::class),
-                new Reference(EventRegistry::class),
-                new Reference(EventSerializer::class),
-                new Reference(TokenMapper::class),
-                new Reference(Store::class),
-            ])
+            ->addTag('container.service_subscriber', ['id' => Store::class])
+            ->addTag('container.service_subscriber', ['id' => AggregateRootRegistry::class])
+            ->addTag('container.service_subscriber', ['id' => EventRegistry::class])
+            ->addTag('container.service_subscriber', ['id' => EventSerializer::class])
+            ->addTag('container.service_subscriber', ['id' => TokenMapper::class])
             ->addTag('twig.extension');
 
         $container->register(HeroiconsExtension::class)

--- a/src/Twig/EventSourcingAdminExtension.php
+++ b/src/Twig/EventSourcingAdminExtension.php
@@ -20,6 +20,8 @@ use Patchlevel\EventSourcing\Store\Store;
 use Patchlevel\EventSourcing\Store\StreamStore;
 use Patchlevel\EventSourcingAdminBundle\Message\Header\RequestIdHeader;
 use Patchlevel\EventSourcingAdminBundle\TokenMapper;
+use Psr\Container\ContainerInterface;
+use Symfony\Contracts\Service\ServiceSubscriberInterface;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
@@ -27,15 +29,50 @@ use function array_pop;
 use function explode;
 use function get_class;
 
-final class EventSourcingAdminExtension extends AbstractExtension
+final class EventSourcingAdminExtension extends AbstractExtension implements ServiceSubscriberInterface
 {
     public function __construct(
-        private readonly AggregateRootRegistry $aggregateRootRegistry,
-        private readonly EventRegistry $eventRegistry,
-        private readonly EventSerializer $eventSerializer,
-        private readonly TokenMapper $tokenMapper,
-        private readonly Store $store,
+        private readonly ContainerInterface $container,
     ) {
+    }
+
+    /**
+     * @return list<class-string>
+     */
+    public static function getSubscribedServices(): array
+    {
+        return [
+            AggregateRootRegistry::class,
+            EventRegistry::class,
+            EventSerializer::class,
+            TokenMapper::class,
+            Store::class,
+        ];
+    }
+
+    private function aggregateRootRegistry(): AggregateRootRegistry
+    {
+        return $this->container->get(AggregateRootRegistry::class);
+    }
+
+    private function eventRegistry(): EventRegistry
+    {
+        return $this->container->get(EventRegistry::class);
+    }
+
+    private function eventSerializer(): EventSerializer
+    {
+        return $this->container->get(EventSerializer::class);
+    }
+
+    private function tokenMapper(): TokenMapper
+    {
+        return $this->container->get(TokenMapper::class);
+    }
+
+    private function store(): Store
+    {
+        return $this->container->get(Store::class);
     }
 
     /** @return list<TwigFunction> */
@@ -71,7 +108,7 @@ final class EventSourcingAdminExtension extends AbstractExtension
      */
     public function aggregateClass(Message $message): string
     {
-        return $this->aggregateRootRegistry->aggregateClass($message->header(AggregateHeader::class)->aggregateName);
+        return $this->aggregateRootRegistry()->aggregateClass($message->header(AggregateHeader::class)->aggregateName);
     }
 
     /** @param Message<object> $message */
@@ -88,7 +125,7 @@ final class EventSourcingAdminExtension extends AbstractExtension
 
     public function usesStreamStore(): bool
     {
-        return $this->store instanceof StreamStore;
+        return $this->store() instanceof StreamStore;
     }
 
     /** @param Message<object> $message */
@@ -148,13 +185,13 @@ final class EventSourcingAdminExtension extends AbstractExtension
     /** @param Message<object> $message */
     public function eventName(Message $message): string
     {
-        return $this->eventRegistry->eventName($this->eventClass($message));
+        return $this->eventRegistry()->eventName($this->eventClass($message));
     }
 
     /** @param Message<object> $message */
     public function eventPayload(Message $message): string
     {
-        return $this->eventSerializer->serialize(
+        return $this->eventSerializer()->serialize(
             $message->event(),
             [JsonEncoder::OPTION_PRETTY_PRINT => true],
         )->payload;
@@ -169,6 +206,6 @@ final class EventSourcingAdminExtension extends AbstractExtension
             return null;
         }
 
-        return $this->tokenMapper->get($requestIdHeader->requestId);
+        return $this->tokenMapper()->get($requestIdHeader->requestId);
     }
 }

--- a/src/Twig/EventSourcingAdminExtension.php
+++ b/src/Twig/EventSourcingAdminExtension.php
@@ -36,9 +36,7 @@ final class EventSourcingAdminExtension extends AbstractExtension implements Ser
     ) {
     }
 
-    /**
-     * @return list<class-string>
-     */
+    /** @return list<class-string> */
     public static function getSubscribedServices(): array
     {
         return [

--- a/tests/Unit/PatchlevelEventSourcingBundleTest.php
+++ b/tests/Unit/PatchlevelEventSourcingBundleTest.php
@@ -8,7 +8,6 @@ use Patchlevel\EventSourcing\Metadata\Message\MessageHeaderRegistry;
 use Patchlevel\EventSourcingAdminBundle\Controller\DefaultController;
 use Patchlevel\EventSourcingAdminBundle\Controller\EventController;
 use Patchlevel\EventSourcingAdminBundle\Controller\InspectionController;
-use Patchlevel\EventSourcingAdminBundle\Controller\ProjectionController;
 use Patchlevel\EventSourcingAdminBundle\Controller\StoreController;
 use Patchlevel\EventSourcingAdminBundle\Controller\SubscriptionController;
 use Patchlevel\EventSourcingAdminBundle\DependencyInjection\PatchlevelEventSourcingAdminExtension;


### PR DESCRIPTION
This pull request refactors the `EventSourcingAdminExtension` class to use dependency injection via a service container rather than direct constructor injection. The class now implements `ServiceSubscriberInterface`, allowing it to lazily fetch its dependencies from the container as needed. This change improves flexibility and aligns with Symfony best practices for service management.

Fixes: https://github.com/patchlevel/event-sourcing-admin-bundle/issues/34

Dependency injection and service fetching refactor:

* Changed `EventSourcingAdminExtension` to implement `ServiceSubscriberInterface` and accept a `ContainerInterface` instead of individual dependencies in the constructor. Added `getSubscribedServices()` to declare required services.
* Replaced direct property access to dependencies (e.g., `$this->aggregateRootRegistry`) with private getter methods that fetch services from the container. Updated all usages throughout the class to use these getters.

